### PR TITLE
Feature/opt for multivalue datapoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ store:
   readTimeout: 10
   connectTimeout: 10
   maxRequests: 128
+# allow many values per datapoint (agregated - avg, sum - on read), otherwise overwrites existing datapoint - last value will be kept
+  multiValueDatapoint: true
 # use C* batch statetments - the trade off is: using batch puts load on C*, not using it may cause congestion on disthene side
   batch: true
 # batch size if above is true

--- a/config/disthene.yaml.sample
+++ b/config/disthene.yaml.sample
@@ -18,9 +18,9 @@ store:
   readTimeout: 10
   connectTimeout: 10
   maxRequests: 128
+  multiValueDatapoint: true
   batch: true
   batchSize: 500
-  multiValueDatapoint: true
   pool: 2
 index:
   name: "disthene"

--- a/config/disthene.yaml.sample
+++ b/config/disthene.yaml.sample
@@ -20,6 +20,7 @@ store:
   maxRequests: 128
   batch: true
   batchSize: 500
+  multiValueDatapoint: true
   pool: 2
 index:
   name: "disthene"

--- a/src/main/java/net/iponweb/disthene/config/StoreConfiguration.java
+++ b/src/main/java/net/iponweb/disthene/config/StoreConfiguration.java
@@ -20,6 +20,7 @@ public class StoreConfiguration {
     private boolean batch;
     private int batchSize;
     private int pool;
+    private boolean multiValueDatapoint;
 
     public String getUserName() {
         return userName;
@@ -125,6 +126,14 @@ public class StoreConfiguration {
         this.columnFamily = columnFamily;
     }
 
+    public boolean allowMultiValueDatapoint() {
+        return multiValueDatapoint;
+    }
+
+    public void setMultiValueDatapoint(boolean multiValueDatapoint) {
+        this.multiValueDatapoint = multiValueDatapoint;
+    }
+
     @Override
     public String toString() {
         return "StoreConfiguration{" +
@@ -139,6 +148,7 @@ public class StoreConfiguration {
                 ", batch=" + batch +
                 ", batchSize=" + batchSize +
                 ", pool=" + pool +
+                ", multiValueDatapoint=" + multiValueDatapoint +
                 '}';
     }
 }

--- a/src/main/java/net/iponweb/disthene/service/store/CassandraService.java
+++ b/src/main/java/net/iponweb/disthene/service/store/CassandraService.java
@@ -39,7 +39,9 @@ public class CassandraService {
 
         String query = "UPDATE " +
                 storeConfiguration.getKeyspace() + "." + storeConfiguration.getColumnFamily() +
-                " USING TTL ? SET data = data + ? WHERE tenant = ? AND rollup = ? AND period = ? AND path = ? AND time = ?;";
+                " USING TTL ? SET " +
+                (storeConfiguration.allowMultiValueDatapoint() ? "data = data + ?" : "data = ?") +
+                " WHERE tenant = ? AND rollup = ? AND period = ? AND path = ? AND time = ?;";
 
         SocketOptions socketOptions = new SocketOptions()
                 .setReceiveBufferSize(1024 * 1024)


### PR DESCRIPTION
Added multiValueDatapoint option to allow control of datapoint update strategy - append (current) vs. overwrite (like old graphite).

We have cases when we want to replace value. Of course it could be implemented on read, but since the old data is redundant, I think this change is cleaner and simpler. 
