### PR TITLE
feature/stats_configurable_path_prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,10 @@ stats:
   interval: 60
 # tenant to use for stats
   tenant: "test"
-# hostname to use
+# (optional) hostname to use if not specified system's hostname will be used
   hostname: "disthene-1a"
+# (optional) path prefix for stats metrics, default to ""
+  pathPrefix: ""
 # output stats to log as well
   log: true
 ```

--- a/config/disthene.yaml.sample
+++ b/config/disthene.yaml.sample
@@ -40,4 +40,5 @@ stats:
   interval: 60
   tenant: "test"
   hostname: "disthene-1a"
+  pathPrefix: ""
   log: true

--- a/src/main/java/net/iponweb/disthene/config/StatsConfiguration.java
+++ b/src/main/java/net/iponweb/disthene/config/StatsConfiguration.java
@@ -11,6 +11,7 @@ public class StatsConfiguration {
     private int interval;
     private String tenant;
     private String hostname;
+    private String pathPrefix;
     private boolean log;
 
     public StatsConfiguration() {
@@ -19,11 +20,13 @@ public class StatsConfiguration {
         } catch (UnknownHostException e) {
             hostname = "unknown";
         }
+        pathPrefix = "";
     }
 
     public int getInterval() {
         return interval;
     }
+
 
     public void setInterval(int interval) {
         this.interval = interval;
@@ -45,6 +48,14 @@ public class StatsConfiguration {
         this.hostname = hostname;
     }
 
+    public String getPathPrefix() {
+        return pathPrefix;
+    }
+
+    public void setPathPrefix(String pathPrefix) {
+        this.pathPrefix = pathPrefix;
+    }
+
     public boolean isLog() {
         return log;
     }
@@ -59,6 +70,7 @@ public class StatsConfiguration {
                 "interval=" + interval +
                 ", tenant='" + tenant + '\'' +
                 ", hostname='" + hostname + '\'' +
+                ", pathPrefix='" + pathPrefix + '\'' +
                 ", log=" + log +
                 '}';
     }

--- a/src/main/java/net/iponweb/disthene/config/StatsConfiguration.java
+++ b/src/main/java/net/iponweb/disthene/config/StatsConfiguration.java
@@ -53,7 +53,8 @@ public class StatsConfiguration {
     }
 
     public void setPathPrefix(String pathPrefix) {
-        this.pathPrefix = pathPrefix;
+        // remove right-trailing dot
+        this.pathPrefix = pathPrefix.endsWith(".") ? pathPrefix.replaceAll("\\.+\\z", "") : pathPrefix;
     }
 
     public boolean isLog() {
@@ -62,6 +63,14 @@ public class StatsConfiguration {
 
     public void setLog(boolean log) {
         this.log = log;
+    }
+
+    public String getPath() {
+        if (pathPrefix.isEmpty()) {
+            return hostname;
+        } else {
+            return pathPrefix + "." + hostname;
+        }
     }
 
     @Override

--- a/src/main/java/net/iponweb/disthene/service/stats/StatsService.java
+++ b/src/main/java/net/iponweb/disthene/service/stats/StatsService.java
@@ -130,7 +130,7 @@ public class StatsService implements StatsServiceMBean {
 
             Metric metric = new Metric(
                     statsConfiguration.getTenant(),
-                    statsConfiguration.getHostname() + ".disthene.tenants." + tenant + ".metrics_received",
+                    statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.tenants." + tenant + ".metrics_received",
                     rollup.getRollup(),
                     rollup.getPeriod(),
                     statsRecord.getMetricsReceived(),
@@ -141,7 +141,7 @@ public class StatsService implements StatsServiceMBean {
 
             metric = new Metric(
                     statsConfiguration.getTenant(),
-                    statsConfiguration.getHostname() + ".disthene.tenants." + tenant + ".write_count",
+                    statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.tenants." + tenant + ".write_count",
                     rollup.getRollup(),
                     rollup.getPeriod(),
                     statsRecord.getMetricsWritten(),
@@ -157,7 +157,7 @@ public class StatsService implements StatsServiceMBean {
 
         Metric metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getHostname() + ".disthene.metrics_received",
+                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.metrics_received",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 totalReceived,
@@ -168,7 +168,7 @@ public class StatsService implements StatsServiceMBean {
 
         metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getHostname() + ".disthene.write_count",
+                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.write_count",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 totalWritten,
@@ -179,7 +179,7 @@ public class StatsService implements StatsServiceMBean {
 
         metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getHostname() + ".disthene.store.success",
+                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.store.success",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 storeSuccess,
@@ -190,7 +190,7 @@ public class StatsService implements StatsServiceMBean {
 
         metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getHostname() + ".disthene.store.error",
+                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.store.error",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 storeError,

--- a/src/main/java/net/iponweb/disthene/service/stats/StatsService.java
+++ b/src/main/java/net/iponweb/disthene/service/stats/StatsService.java
@@ -130,7 +130,7 @@ public class StatsService implements StatsServiceMBean {
 
             Metric metric = new Metric(
                     statsConfiguration.getTenant(),
-                    statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.tenants." + tenant + ".metrics_received",
+                    statsConfiguration.getPath() + ".disthene.tenants." + tenant + ".metrics_received",
                     rollup.getRollup(),
                     rollup.getPeriod(),
                     statsRecord.getMetricsReceived(),
@@ -141,7 +141,7 @@ public class StatsService implements StatsServiceMBean {
 
             metric = new Metric(
                     statsConfiguration.getTenant(),
-                    statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.tenants." + tenant + ".write_count",
+                    statsConfiguration.getPath() + ".disthene.tenants." + tenant + ".write_count",
                     rollup.getRollup(),
                     rollup.getPeriod(),
                     statsRecord.getMetricsWritten(),
@@ -157,7 +157,7 @@ public class StatsService implements StatsServiceMBean {
 
         Metric metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.metrics_received",
+                statsConfiguration.getPath() + ".disthene.metrics_received",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 totalReceived,
@@ -168,7 +168,7 @@ public class StatsService implements StatsServiceMBean {
 
         metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.write_count",
+                statsConfiguration.getPath() + ".disthene.write_count",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 totalWritten,
@@ -179,7 +179,7 @@ public class StatsService implements StatsServiceMBean {
 
         metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.store.success",
+                statsConfiguration.getPath() + ".disthene.store.success",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 storeSuccess,
@@ -190,7 +190,7 @@ public class StatsService implements StatsServiceMBean {
 
         metric = new Metric(
                 statsConfiguration.getTenant(),
-                statsConfiguration.getPathPrefix() + statsConfiguration.getHostname() + ".disthene.store.error",
+                statsConfiguration.getPath() + ".disthene.store.error",
                 rollup.getRollup(),
                 rollup.getPeriod(),
                 storeError,


### PR DESCRIPTION
Currently disthene push metrics to the path `<hostname>.disthene....`, having dozens of ip/hostnames (and rotating instance on daily basis) in the top-level introduces too much noise in our case. This PR enables to test custom path for stats metrics.